### PR TITLE
WIP: Multi-arch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ run: install build ## Connect to a local Kubernetes cluster, install the operato
 
 #docker-build: test ## Build docker image with the manager.
 docker-build: build ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker buildx build --platform linux/amd64,linux/arm64 -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}


### PR DESCRIPTION
Considering the postgres image is multi-arch is would be really great to have the operator multi-arch as well. I have multi-arch clusters.

I started a small unfinished PR and hopping someone can take over the Dockerfile process. I'm a podman/buildah user and this has been too hard making assumptions of how Docker buildx works.

The Docker buildX docs are here https://docs.docker.com/buildx/working-with-buildx/

The dockerfile edits would look like something like:

```Dockerfile
SHELL ["/bin/bash", "-o", "pipefail", "-c"]
RUN \
  export GOOS \
  && GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) \
  && export GOARCH \
  && GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
  && export GOARM \
  && GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) \
&& go mod download

# Copy the go source
COPY main.go main.go
COPY api/ api/
COPY controllers/ controllers/

SHELL ["/bin/bash", "-o", "pipefail", "-c"]

# Build
RUN \
  export GOOS \
  && GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) \
  && export GOARCH \
  && GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) \
  && export GOARM \
  && GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) \
&& go build -a -o manager main.go

```