### PR TITLE
Anthr76 multi arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,8 @@ run: install build ## Connect to a local Kubernetes cluster, install the operato
 	go run ./main.go
 
 #docker-build: test ## Build docker image with the manager.
-docker-build: build ## Build docker image with the manager.
-	docker buildx build --platform linux/amd64,linux/arm64 -t ${IMG} .
-
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+docker-build-push: build ## Build docker image with the manager.
+	docker buildx build --platform linux/amd64,linux/arm64 -t ${IMG} --push .
 
 ##@ Deployment
 
@@ -89,7 +86,7 @@ endif
 ## eg: 'make deploy IMG=reactivetechio/kubegres:1.4'
 ## Run acceptance tests then deploy into Docker Hub the controller as the Docker image provided in arg ${IMG}
 ## and update the local file "kubegres.yaml" with the image ${IMG}
-deploy: deploy-check test docker-build docker-push kustomize
+deploy: deploy-check test docker-build-push kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > kubegres.yaml
 	@echo "DEPLOYED $(IMG) INTO DOCKER HUB. UPDATED 'kubegres.yaml' WITH '$(IMG)'. YOU CAN COMMIT 'kubegres.yaml' AND CREATE A RELEASE IN GITHUB."

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ run: install build ## Connect to a local Kubernetes cluster, install the operato
 
 #docker-build: test ## Build docker image with the manager.
 docker-build: build ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker buildx build --platform linux/amd64,linux/arm64 -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: reactivetechio/kubegres
-  newTag: "1.6"
+  newTag: "1.7"

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -518,7 +518,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: reactivetechio/kubegres:1.6
+        image: reactivetechio/kubegres:1.7
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
In the branch https://github.com/reactive-tech/kubegres/tree/anthr76-multi-arch I made few small changes such as adding the option "--pull" in "docker buildx .." command and I modified "kubegres.yaml" in the root folder so that you can deploy and test locally the arm version in your local Kubernetes cluster as follows:

```
kubectl apply -f kubegres.yaml
```

Can you do a test for me?

The command above will deploy from Docker Hub Kubegres version 1.7 which contains the images for amd and arm as follows:
https://hub.docker.com/layers/reactivetechio/kubegres/1.7/images/sha256-effbba559b1595c9153684a2f39a2d10e6e14d5017180d930b1bdbb7f2330299?context=repo

