### PR TITLE
Use Bitnami kube-rbac-proxy image source

### DIFF
--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -2428,7 +2428,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: bitnami/kube-rbac-proxy:0.14.0
+        image: bitnami/kube-rbac-proxy:0.13.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -2428,7 +2428,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: bitnami/kube-rbac-proxy:0.14.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Swaps the kubegres-controller-manager image source from kubebuilder on gcr.io to bitnami on dockerhub which resolves #152 