### PR TITLE
kube-rbac-proxy:v0.13.0 -> 0.13.1

### DIFF
--- a/kubegres.yaml
+++ b/kubegres.yaml
@@ -2428,7 +2428,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
- Fixes CVEs https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.13.1
-  I think kubegres-controller-manager image needs to be updated for same CVEs


Used this excellent project for doing the scanning if you haven't used it already.

https://github.com/aquasecurity/trivy

 Title:              golang: net/http: handle server errors after sending GOAWAY
    Vulnerability ID:   CVE-2022-27664
    Fixed Version:      0.7.0
    Installed Version:  v0.0.0-20220127200216-cd36cc0744dd
    Links:
    Primary Link:       https://avd.aquasec.com/nvd/cve-2022-41723
    Resource:           golang.org/x/net
    Severity:           HIGH
    Target:
    
    Your project is excellent. Thank you!